### PR TITLE
Adding FluentValidator and Filters Middleware

### DIFF
--- a/Tweetbook/Contracts/V1/Responses/ErrorModel.cs
+++ b/Tweetbook/Contracts/V1/Responses/ErrorModel.cs
@@ -1,0 +1,9 @@
+﻿namespace Tweetbook.Contracts.V1.Responses
+{
+   public class ErrorModel
+   {
+      public string FieldName { get; set; }
+
+      public string Message { get; set; }
+   }
+}

--- a/Tweetbook/Contracts/V1/Responses/ErrorResponse.cs
+++ b/Tweetbook/Contracts/V1/Responses/ErrorResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace Tweetbook.Contracts.V1.Responses
+{
+   public class ErrorResponse
+   {
+      public List<ErrorModel> Errors { get; set; } = new List<ErrorModel>();
+   }
+}

--- a/Tweetbook/Controllers/V1/TagsController.cs
+++ b/Tweetbook/Controllers/V1/TagsController.cs
@@ -8,6 +8,7 @@ using Tweetbook.Contracts.V1.Responses;
 using Tweetbook.Domain;
 using Tweetbook.Extensions;
 using Tweetbook.Services;
+using Tweetbook.Validators;
 
 namespace Tweetbook.Controllers.V1
 {

--- a/Tweetbook/Filters/ValidationFilter.cs
+++ b/Tweetbook/Filters/ValidationFilter.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Tweetbook.Contracts.V1.Responses;
+
+namespace Tweetbook.Filters
+{
+   public class ValidationFilter : IAsyncActionFilter
+   {
+      public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+      {
+         // Action executed before the controller
+
+         // Since we're using FluentValidator, we can now automatically validate user input
+         // against ASP.NET Core's ModelState.
+         if (!context.ModelState.IsValid)
+         {
+            var errorsInModelState = context.ModelState
+               .Where(x => x.Value.Errors.Count > 0)
+               .ToDictionary(kv => kv.Key, kv => kv.Value.Errors.Select(x => x.ErrorMessage)).ToArray();
+
+            var errorResponse = new ErrorResponse();
+
+            foreach (var error in errorsInModelState)
+            {
+               foreach (var subError in error.Value)
+               {
+                  var errorModel = new ErrorModel
+                  {
+                     FieldName = error.Key,
+                     Message = subError
+                  };
+
+                  errorResponse.Errors.Add(errorModel);
+               }
+            }
+            context.Result = new BadRequestObjectResult(errorResponse);
+            return;
+         }
+
+         await next();
+
+         // Action executed after the controller
+      }
+   }
+}

--- a/Tweetbook/Program.cs
+++ b/Tweetbook/Program.cs
@@ -1,3 +1,5 @@
+using FluentValidation;
+using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -5,6 +7,7 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using System.Text;
 using Tweetbook.Data;
+using Tweetbook.Filters;
 using Tweetbook.Options;
 using Tweetbook.Services;
 using SwaggerOptions = Tweetbook.Options.SwaggerOptions;
@@ -13,7 +16,11 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
-builder.Services.AddControllers();
+builder.Services.AddControllers(options =>
+    {
+        // Add input validation filters middleware (to be used with FluentValidation).
+        options.Filters.Add<ValidationFilter>();
+    });
 
 // Register our DataContext as a service.
 builder.Services.AddDbContext<DataContext>(options =>
@@ -81,6 +88,7 @@ builder.Services.AddSwaggerGen(x =>
 });
 
 builder.Services.AddAutoMapper(typeof(Program));
+builder.Services.AddFluentValidationAutoValidation().AddValidatorsFromAssemblyContaining<Program>();
 
 var app = builder.Build();
 

--- a/Tweetbook/Properties/launchSettings.json
+++ b/Tweetbook/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7247;http://localhost:5014",
+      "applicationUrl": "http://localhost:5014;https://localhost:7247",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/Tweetbook/Tweetbook.csproj
+++ b/Tweetbook/Tweetbook.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />

--- a/Tweetbook/Validators/CreateTagRequestValidator.cs
+++ b/Tweetbook/Validators/CreateTagRequestValidator.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+using Tweetbook.Contracts.V1.Requests;
+
+namespace Tweetbook.Validators
+{
+   public class CreateTagRequestValidator : AbstractValidator<CreateTagRequest>
+   {
+      public CreateTagRequestValidator()
+      {
+         RuleFor(x => x.TagName)
+            .NotNull()
+            .NotEmpty()
+            .Matches("^[a-zA-Z0-9 ]*$");
+      }
+   }
+}


### PR DESCRIPTION
This PR adds FluentValidator to validate the inputs to the API conform to the model specified in the contracts.
Also, filtering middleware is added to help with error responses due to failed validations.